### PR TITLE
Put the ReactOS Website Theme entirely under MIT License and remove no longer needed attributions on every page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -135,7 +135,6 @@ paginate = 10
 
 [params]
 	viewMorePostLink = "/news/"
-	author = "DevCows"
 	defaultKeywords = ["ReactOS", "react", "os", "open source", "free", "win32", "winapi"]
 	defaultDescription = "ReactOS is a free, opensource reimplementation of windows"
 

--- a/themes/reactos/LICENSE
+++ b/themes/reactos/LICENSE
@@ -1,6 +1,30 @@
+The ReactOS Website Theme in "themes/reactos" is originally derived from the
+"Bootstrapious Universal - Business & E-commerce Template" available at
+https://bootstrapious.com/p/universal-business-e-commerce-template
+The theme is Copyright (c) Ondrej Svestka <hello@bootstrapious.com>,
+All Rights Reserved
+
+The ReactOS Website Theme is further derived from the "Universal Theme for
+Hugo" available at https://github.com/devcows/hugo-universal-theme
+This one is Copyright (c) 2016 DevCows and available under the MIT License
+(SPDX short identifier: MIT)
+
+On 2020-02-18, ReactOS Deutschland e.V. has purchased an "extended license"
+for the original "Bootstrapious Universal - Business & E-commerce Template".
+Ondrej Svestka states that an extended license allows to "relicense one of my
+free themes, e.g. to sell its derivative on ThemeForest without any
+attribution, include it into the SAAS app or generally change the license for
+his/her product".
+ReactOS Deutschland e.V. hereby makes all files in "themes/reactos" and
+subdirectories available under the following combined license:
+
+==============================================================================
 The MIT License (MIT)
 
+Copyright (c) 2020 Ondrej Svastka
 Copyright (c) 2016 DevCows
+Copyright (c) 2020 ReactOS Deutschland e.V.
+Copyright (c) 2020 ReactOS Website Theme Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +43,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+==============================================================================

--- a/themes/reactos/layouts/partials/footer.html
+++ b/themes/reactos/layouts/partials/footer.html
@@ -11,10 +11,6 @@
 		</div>
 
 		<div class="col-md-4 text-right">
-			{{ i18n "templateBy" }} <a href="http://bootstrapious.com/free-templates">Bootstrapious</a>.
-			<!-- Not removing this link is part of the licence conditions of the template. Thanks for understanding :) -->
-			{{ i18n "portedBy" }} <a href="https://github.com/devcows/hugo-universal-theme">DevCows</a>
-
 			<div class="pull-right">
 				<div class="social">
 					<a href="https://github.com/reactos" target="_blank"><i class="fa fa-github"></i></a>


### PR DESCRIPTION
An "extended license" for the original "Bootstrapious Universal - Business & E-commerce Template" at https://bootstrapious.com/p/universal-business-e-commerce-template has been purchased by ReactOS Deutschland e.V.
This license comes with the right to freely relicense the original work by Bootstrapious, which finally enables us to fix the license compliance issues we were facing and remove the attributions on every page.

This PR puts everything in "themes/reactos" and subdirectories under the MIT License. The complete license text can be found in the "LICENSE" file.
**By accepting this PR, you reaffirm your previous implicit declaration to put all your contributions to the ReactOS Website Theme under the same MIT License.**