### PR TITLE
Add a news item about our website launch

### DIFF
--- a/content/project-news/the-new-reactos-website.md
+++ b/content/project-news/the-new-reactos-website.md
@@ -1,0 +1,26 @@
++++
+title = "The New ReactOS Website"
+author = "Colin Finck"
+date = 2020-03-15
++++
+
+Today, I am pleased to announce the launch of the new ReactOS website.  
+Several [old and new ReactOS members](https://github.com/reactos/web-content/graphs/contributors) have worked on it since [Hackfest 2018](/wiki/ReactOS_Hackfest_2018) with the goal of providing a lean website with a focus on development activity and contributions.
+
+It was born out of frustration with the old site, which made following ReactOS progress unnecessarily difficult.
+With its CMS also long past its due date, it was decided to create a modern ReactOS website from scratch using the excellent [Hugo](https://gohugo.io/) static site generator.
+We have chosen a design centered around project news and developer blogs, making it easy for you to follow the daily ReactOS activity.  
+Contributing to the new site also got a lot simpler:
+The entire content is managed in a [repository](https://github.com/reactos/web-content) on GitHub.
+Just fork it, write your proposed changes in Markdown or HTML, and open a pull request to let us know about them.
+You don't even need to look up the relevant files yourself:
+We added a direct link *Improve this page* to the bottom of every page.
+
+To better understand our philosophy, let's also explain what the new ReactOS website is not.  
+It is not another clickbait site that is constantly distracting you from the actual content and tracking your every move.
+In this age of ever-eroding privacy, the new ReactOS website wants to be a counterexample on how to build a website that protects your data instead of sharing it with third parties.
+As such, the main website works without any cookies or third-party resources, and we have taken [technical measures](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to ensure that.
+After our cleanup, there is only a single external service left, which is used for spam prevention during account registration and wiki edits.  
+All in all, ReactOS shall be an operating system you can trust, and this also applies to our website.
+
+We hope that you like our new site, and that it succeeds in attracting the next generation of ReactOS developers and community members.

--- a/content/project-news/the-new-reactos-website.md
+++ b/content/project-news/the-new-reactos-website.md
@@ -1,7 +1,7 @@
 +++
 title = "The New ReactOS Website"
 author = "Colin Finck"
-date = 2020-03-15
+date = 2020-03-21
 +++
 
 Today, I am pleased to announce the launch of the new ReactOS website.  


### PR DESCRIPTION
I plan to launch the new ReactOS website on 2020-03-21, and this is the announcement I have written for the launch.
I invite the core ReactOS Team, contributors to the new website, and native English speakers to have a look at my announcement, and confirm it or suggest changes. This PR shall also serve as a first example on how we can collaborate on website content in the future :)