### PR TITLE
[GALLERY] Improve the caption of Mizu Search screenshot (addendum to 2e34f12)

### DIFF
--- a/content/gallery.md
+++ b/content/gallery.md
@@ -16,7 +16,7 @@ scripts = [
 
 {{< gallery >}}
 {{< figure link="/sites/default/files/Mizu-AppManager.png" caption="Applications Manager" >}}
-{{< figure link="/sites/default/files/Mizu-Search.png" caption="Search" >}}
+{{< figure link="/sites/default/files/Mizu-Search.png" caption="File Search" >}}
 {{< figure link="/sites/default/files/Mizu-VLC.png" caption="VLC" >}}
 {{< figure link="/sites/default/files/Mizu-Neverball.png" caption="Neverball" >}}
 {{< figure link="/sites/default/files/Mizu-Teeworlds.png" caption="Teeworlds" >}}


### PR DESCRIPTION
Search -> File Search
In my opinion it's more understandable than just "Search".
Before:
![before](https://user-images.githubusercontent.com/26385117/77248410-d88cc680-6c41-11ea-8899-245bc4753a97.png)

After:
![after](https://user-images.githubusercontent.com/26385117/77248417-e17d9800-6c41-11ea-9961-710cc9a26626.png)