### PR TITLE
[DOWNLOAD] Fix wrong cursor on LiveCD button

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -17,7 +17,7 @@ scripts = [
 
 <div class="text-center">
 	<a id="bootcd" class="modalbtn" href="https://sourceforge.net/projects/reactos/files/ReactOS/{{< reactos-version >}}/ReactOS-{{< reactos-version >}}-iso.zip/download"><div class="ros-button">Download Boot CD</div></a>
-	<p>Alternatively, you can download <a id="livecd" class="modalbtn" href="https://sourceforge.net/projects/reactos/files/ReactOS/{{< reactos-version >}}/ReactOS-{{< reactos-version >}}-live.zip/download">LiveCD</a></p>
+	<p>Alternatively, you can download <a id="livecd" class="modalbtn" onmouseover="this.style.cursor='pointer'" href="https://sourceforge.net/projects/reactos/files/ReactOS/{{< reactos-version >}}/ReactOS-{{< reactos-version >}}-live.zip/download">LiveCD</a></p>
 </div>
 
 <h2>How to choose?</h2>


### PR DESCRIPTION
Fix incorrect mouse cursor when hover the mouse on LiveCD button below BootCD's one on Download page.
Currently, when hover the mouse on that button, it displays a text cursor (same as on the text selection), unlike other buttons. After my fix, it became a pointer cursor (which is correct for links and buttons).
Although I fixed it in content/download.html by forcing the `cursor` parameter to `pointer`, it seems to me a bit hacky way, since, as I see, it depends on `cursor:` parameter in ros-design.css instead, but changing the last one doesn't fix the problem for me for some reason. But other buttons are displayed correctly without forcing cursor type in html instead of css. Or they are different than LiveCD button, so they don't need fixing html?... :thinking: 