### PR TITLE
Add a link on Jira Activity Stream below the Live Activity for faster access to it

### DIFF
--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -46,6 +46,8 @@
 			</div>
 
 			<ul id="jirafeed"></ul>
+			
+			<a href="https://jira.reactos.org/secure/Dashboard.jspa#Activity-Stream/10001">More...</a>
 		</div>
 	</div>
 </section>

--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -47,7 +47,7 @@
 
 			<ul id="jirafeed"></ul>
 			
-			<a href="https://jira.reactos.org/secure/Dashboard.jspa#Activity-Stream/10001">More...</a>
+			<a href="https://jira.reactos.org">More...</a>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
Add the link on Jira Activity Stream below the Live Activity feed, in order to have an easier access to it. Then it will not necessarily need to open a Development menu and then a Jira entry at the top.
In my opinion, it will be useful for newcomers, who don't orientate on our new website yet, and want to see all development activity. Moreover, it already was done similar on the old website, so I think it's a good feature.
![Снимок экрана от 2020-03-22 22-06-13](https://user-images.githubusercontent.com/26385117/77259340-663fd480-6c89-11ea-9cf3-e37d6348e85f.png)

Before:
![Screenshot_2020-03-22 before](https://user-images.githubusercontent.com/26385117/77259383-b6b73200-6c89-11ea-9f48-55a288f2783a.png)

After:
![Screenshot_2020-03-22 after](https://user-images.githubusercontent.com/26385117/77259386-bd45a980-6c89-11ea-9b81-6684e2c658be.png)