### PR TITLE
[STATIC][CSS] Force the footer to stay at the bottom of the page

### DIFF
--- a/themes/reactos/layouts/404.html
+++ b/themes/reactos/layouts/404.html
@@ -7,7 +7,7 @@
 			{{ partial "nav.html" . }}
 		</header>
 
-		<div class="container-fluid">	
+		<div class="container-fluid" id="main-content">	
 			<section id="content" class="row">
 				<div class="col-sm-6 col-sm-offset-3" id="error-page">
 					<div class="box">
@@ -24,10 +24,9 @@
 					</div>
 				</div>
 			</section>
-
-			{{ partial "footer.html" . }}
 		</div>
 
+		{{ partial "footer.html" . }}
 		{{ partial "scripts.html" . }}
 	</body>
 </html>

--- a/themes/reactos/layouts/_default/single.html
+++ b/themes/reactos/layouts/_default/single.html
@@ -9,7 +9,7 @@
 
 		{{ partial "load-photoswipe.html" . }}
 
-		<div class="container-fluid">
+		<div class="container-fluid" id="main-content">
 			{{ partial "breadcrumbs.html" . }}
 
 			<section id="content" class="row">
@@ -23,10 +23,9 @@
 					</div>
 				</div>
 			</section>
-
-			{{ partial "footer.html" . }}
 		</div>
 
+		{{ partial "footer.html" . }}
 		{{ partial "scripts.html" . }}
 	</body>
 </html>

--- a/themes/reactos/layouts/index.html
+++ b/themes/reactos/layouts/index.html
@@ -10,12 +10,12 @@
 		{{ partial "nav.html" . }}
 	</header>
 
-	<div class="container-fluid">
+	<div class="container-fluid" id="main-content">
 		{{ .Content }}
 		{{ partial "recent_posts.html" . }}
-		{{ partial "footer.html" . }}
 	</div>
 
+	{{ partial "footer.html" . }}
 	{{ partial "scripts.html" . }}
 </body>
 </html>

--- a/themes/reactos/layouts/page/single.html
+++ b/themes/reactos/layouts/page/single.html
@@ -9,7 +9,7 @@
 
 		{{ partial "load-photoswipe.html" . }}
 
-		<div class="container-fluid">
+		<div class="container-fluid" id="main-content">
 			{{ partial "breadcrumbs.html" . }}
 
 			<section id="content" class="row">
@@ -21,10 +21,9 @@
 					{{ end }}
 				</div>
 			</section>
-
-			{{ partial "footer.html" . }}
 		</div>
 
+		{{ partial "footer.html" . }}
 		{{ partial "scripts.html" . }}
 	</body>
 </html>

--- a/themes/reactos/layouts/partials/footer.html
+++ b/themes/reactos/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="row" id="copyright">
+<footer id="copyright">
 	<div class="col-md-offset-1 col-md-10">
 		<div class="row">
 			<div class="col-sm-4 col-md-4 col-left">&copy; 1996-{{ now.Year }} ReactOS Team &amp; Contributors</div>

--- a/themes/reactos/layouts/partials/page.html
+++ b/themes/reactos/layouts/partials/page.html
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container-fluid" id="main-content">
 	<div class="col-md-10 col-md-offset-1">
 		{{ .Content }}
 	</div>

--- a/themes/reactos/layouts/partials/shared-list.html
+++ b/themes/reactos/layouts/partials/shared-list.html
@@ -8,7 +8,7 @@
 			{{ partial "nav.html" . }}
 		</header>
 
-		<div class="container-fluid">
+		<div class="container-fluid" id="main-content">
 			{{ partial "breadcrumbs.html" . }}
 
 			<section id="content" class="row">
@@ -66,10 +66,9 @@
 					</div>
 				</div>
 			</section>
-			
-			{{ partial "footer.html" . }}
 		</div>
 
+		{{ partial "footer.html" . }}
 		{{ partial "scripts.html" . }}
 	</body>
 

--- a/themes/reactos/layouts/parts/single.html
+++ b/themes/reactos/layouts/parts/single.html
@@ -15,18 +15,16 @@
     {{ partial "nav.html" . }}
 </header>
 
-<div class="container-fluid">
+<div class="container-fluid" id="main-content">
 
 <!-- End header template -->
+</div>
 
 {{ else if (eq .Slug "footer") }}
 
 <!-- Begin footer template -->
-
     
-    {{ partial "footer.html" . }}
-</div>
-
+{{ partial "footer.html" . }}
 {{ partial "scripts.html" . }}
 
 <!-- End footer template -->

--- a/themes/reactos/static/css/style.blue.css
+++ b/themes/reactos/static/css/style.blue.css
@@ -25,6 +25,14 @@
 	display: block !important;
 }
 
+html, body {
+	height: 100%;
+}
+
+div#main-content {
+	flex: 1 0 auto;
+}
+
 /* general styles */
 a,
 button {
@@ -578,6 +586,7 @@ fieldset[disabled] .btn-template-main.active {
 }
 
 #copyright {
+	flex-shrink: 0;
 	background: #333;
 	color: #ccc;
 	padding: 20px 0;
@@ -1006,6 +1015,8 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 }
 /* scaffolding */
 body {
+	display: flex;
+	flex-direction: column;
 	font-family: "Roboto", Helvetica, Arial, sans-serif;
 	font-size: 16px;
 	line-height: 1.42857143;


### PR DESCRIPTION
Pages like `What is ReactOS?` whose content is relatively small the footer is positioned a bit upper based on viewport instead to stay at the bottom.
**BEFORE:**
![Capture2](https://user-images.githubusercontent.com/34916900/77821643-154a3900-70ec-11ea-93cd-ba614a2178a5.PNG)
**AFTER:**
![Capture](https://user-images.githubusercontent.com/34916900/77821647-1bd8b080-70ec-11ea-80ed-1a15e8bdd24f.PNG)
