### PR TITLE
Add a button to All News category below the Recent News on the main page for faster access to it

### DIFF
--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -39,10 +39,9 @@
 
 			{{ end }}
 
-		<ul class="pager">
-			<li class="next"><a href="/news">Older posts →</a></li>
-		</ul>
-
+			<ul class="pager">
+				<li class="next"><a href="/news">Older posts →</a></li>
+			</ul>
 		</div>
 
 		<div class="col-md-3">

--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -38,6 +38,11 @@
 			</section>
 
 			{{ end }}
+
+		<ul class="pager">
+			<li class="next"><a href="https://pr71.web-content.reactos.org/news">Older posts →</a></li>
+		</ul>
+
 		</div>
 
 		<div class="col-md-3">

--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -40,7 +40,7 @@
 			{{ end }}
 
 		<ul class="pager">
-			<li class="next"><a href="https://pr71.web-content.reactos.org/news">Older posts →</a></li>
+			<li class="next"><a href="/news">Older posts →</a></li>
 		</ul>
 
 		</div>


### PR DESCRIPTION
Add a button to All News category below the Recent News on the main page, for more easy access to it, same as I did it for Live Activity feed. Then it will not required to open the News -> All News at the top, what will easier, e. g. for newcomers, if they will want to immediately switch to all news.
Before:
![news-before](https://user-images.githubusercontent.com/26385117/87463353-ee236300-c619-11ea-9101-5f1df62141fa.png)
After:
![news-after](https://user-images.githubusercontent.com/26385117/87463382-f67b9e00-c619-11ea-9e6b-429a71c9e816.png)