### PR TITLE
[GALLERY] Fix position of caption under screenshots when viewing each screenshot separately

### DIFF
--- a/static/css/default-skin/default-skin.css
+++ b/static/css/default-skin/default-skin.css
@@ -271,7 +271,7 @@ a.pswp__share--download:hover {
     color: #BBB; }
 
 .pswp__caption__center {
-  text-align: left;
+  text-align: center;
   max-width: 420px;
   margin: 0 auto;
   font-size: 13px;


### PR DESCRIPTION
Currently it's incorrect (aligned by left), and this looks a bit crooked. So align it by center instead.
Before:
![gallery_before](https://user-images.githubusercontent.com/26385117/91893380-b1303000-ec9c-11ea-9234-7ad08cb6068a.png)
After:
![gallery_after](https://user-images.githubusercontent.com/26385117/91893402-bab99800-ec9c-11ea-85fe-f89fc2fa167c.png)