### PR TITLE
Fix ReactOS Shop link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,7 +66,7 @@ paginate = 10
 	[[menu.main]]
 		parent = "Community"
 		name = "Shop"
-		url  = "https://reactos.spreadshirt.net"
+		url  = "https://shop.spreadshirt.net/reactos/"
 		weight = 203
 
 [[menu.main]]


### PR DESCRIPTION
Not sure how long the old one has been broken, but I've fixed that now.
Also cleaned up the shop and added a lot of products based on the ReactOS logo of our latest merchandising from 2019. Was fun :)