### PR TITLE
Update default download for releases/0.4.14

### DIFF
--- a/themes/reactos/layouts/shortcodes/reactos-download-version.html
+++ b/themes/reactos/layouts/shortcodes/reactos-download-version.html
@@ -1,1 +1,1 @@
-0.4.14-release-21-g1302c1b
+0.4.14-release-29-g8a2dc46


### PR DESCRIPTION
changelog are the last 8 commits from https://git.reactos.org/?p=reactos.git;a=shortlog;h=refs/heads/releases/0.4.14 Motivation to update the URL now is the most recent commit specifically: ECDSA P384. bootcd/livecd/src are already uploaded to sf: https://sourceforge.net/projects/reactos/files/ReactOS/0.4.14/ And sf default download points to the new bootcd iso already.