### PR TITLE
[INDEX] Change "get nightly builds" wording

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -49,6 +49,6 @@ scripts = [
 			<a href="/donate" class="btn btn-success">Donate</a>
 		</div>
 
-		<div>Missing something in the release? Try <a href="/getbuilds">nightly builds</a> instead.</div>
+		<div>To get the latest features and bugfixes, get <a href="/getbuilds">nightly builds</a> instead.</div>
 	</div>
 </section>

--- a/content/_index.html
+++ b/content/_index.html
@@ -49,6 +49,6 @@ scripts = [
 			<a href="/donate" class="btn btn-success">Donate</a>
 		</div>
 
-		<div>To get the latest features and bugfixes, get <a href="/getbuilds">nightly builds</a> instead.</div>
+		<div>For the latest features and bugfixes, try our <a href="/getbuilds">nightly builds</a>.</div>
 	</div>
 </section>

--- a/content/_index.html
+++ b/content/_index.html
@@ -49,6 +49,6 @@ scripts = [
 			<a href="/donate" class="btn btn-success">Donate</a>
 		</div>
 
-		<div>For the latest features and bugfixes, try our <a href="/getbuilds">nightly builds</a>.</div> 
+		<div>For the latest features and bugfixes, try our <a href="/getbuilds">nightly builds</a>.</div>
 	</div>
 </section>

--- a/content/_index.html
+++ b/content/_index.html
@@ -49,6 +49,6 @@ scripts = [
 			<a href="/donate" class="btn btn-success">Donate</a>
 		</div>
 
-		<div>For the latest features and bugfixes, try our <a href="/getbuilds">nightly builds</a>.</div>
+		<div>For the latest features and bugfixes, try our <a href="/getbuilds">nightly builds</a>.</div> 
 	</div>
 </section>


### PR DESCRIPTION
Changes it to something more clear and straight to the point.
The previous wording might be confusing, thus not drawing attention to it.

BEFORE:
"Missing something in the release? Try nightly builds instead."

AFTER:
"To get the latest features and bugfixes, get nightly builds instead."

If you think it can be further improved, please let me know. Thanks.