### PR TITLE
[FOOTER] Fix displaying current copyright year

### DIFF
--- a/themes/reactos/layouts/partials/footer.html
+++ b/themes/reactos/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer id="copyright">
 	<div class="col-md-offset-1 col-md-10">
 		<div class="row">
-			<div class="col-sm-4 col-md-4 col-left">&copy; 1996-{{ now.Year }} ReactOS Team &amp; Contributors</div>
+			<div class="col-sm-4 col-md-4 col-left">&copy; 1996-<script>document.write(new Date().getFullYear())</script> ReactOS Team &amp; Contributors</div>
 
 			<div class="col-sm-3 col-md-4 col-center">
 				{{ if and (.File) (ne .Slug "footer") }}


### PR DESCRIPTION
Use HTML5/JavaScript provided `Date().getFullYear()` method to get the current copyright year, instead of undefined `now.Year` variable, which seems to be no longer working properly, since the copyright year did not update correctly.

Jira issue: [ONLINE-917](https://jira.reactos.org/browse/ONLINE-917).

Result:
Before:
![before](https://github.com/user-attachments/assets/df96abf0-a822-4271-94a3-f8028e4e54ef)
After:
![after](https://github.com/user-attachments/assets/0082de67-22ee-42c0-9837-b451f34dc0b7)