### PR TITLE
[WEBSITE] Link to Release Notes from Downloads

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -15,6 +15,7 @@ date: 2021-01-23
 
 <div class="text-center">
 	<a id="bootcd" class="modalbtn" href="https://downloads.sourceforge.net/reactos/ReactOS-{{< reactos-download-version >}}-iso.zip"><div class="ros-button">Download Boot CD</div></a>
+	<a class="modalbtn" href="{{< reactos-release-notes >}}"><div class="ros-button ros-button-secondary">Release Notes</div></a>
 	<p>Alternatively, you can download <a id="livecd" class="modalbtn" href="https://downloads.sourceforge.net/reactos/ReactOS-{{< reactos-download-version >}}-live.zip">LiveCD</a></p>
 </div>
 

--- a/static/css/ros-design.css
+++ b/static/css/ros-design.css
@@ -12,6 +12,15 @@
 .ros-button:active {
 	background: #436477;
 }
+.ros-button-secondary {
+	background: #6e6e6e;
+}
+.ros-button-secondary:hover {
+	background: #8c8c8c;
+}
+.ros-button-secondary:active {
+	background: #5c5c5c;
+}
 .ros-button-sm {
 	padding: 0.25em 0.5em;
 }

--- a/themes/reactos/layouts/shortcodes/reactos-release-notes.html
+++ b/themes/reactos/layouts/shortcodes/reactos-release-notes.html
@@ -1,0 +1,1 @@
+https://reactos.org/project-news/reactos-0414-released/


### PR DESCRIPTION
Adds a big "Release Notes" button.
![image](https://github.com/user-attachments/assets/8d3bc6ce-69da-4537-96e9-c03aa39d68f6)

The new "Release Notes" button is probably too big; if it is, how should it be?

we could avoid the "reactos-release-notes.html" shortcode if we form a link like `https://reactos.org//project-news/reactos-{{< reactos-version >}}-released/` and add an alias to reactos-041-released.html like: `aliases: [ "/node/9485", "/project-news/reactos-0.4.1-released" ]`. would that be better?