### PR TITLE
Reword the download.html page, removing mentions of deprecated LiveCD

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -14,12 +14,14 @@ date: 2021-01-23
 </div>
 
 <div class="text-center">
-	<a id="bootcd" class="modalbtn" href="https://sourceforge.net/projects/reactos/files/latest/download"><div class="ros-button">Download Boot CD</div></a>
-	<p>Alternatively, you can download <a id="livecd" class="modalbtn" href="https://sourceforge.net/projects/reactos/files/ReactOS/0.4.15/ReactOS-{{< reactos-download-version >}}-x86-live.zip/download">LiveCD</a></p>
+	<a id="bootcd" class="modalbtn" href="https://sourceforge.net/projects/reactos/files/latest/download"><div class="ros-button">Download Boot Media</div></a>
 </div>
 
-<h2>How to choose?</h2>
-<p>If you wish to install ReactOS on your machine, then Boot CD is the right option for you. Boot CD will direct you to a setup environment, please follow the instructions given on the screen. Live CD is useful if you don't plan to keep ReactOS on your computer for a longer period of time. It allows you to explore ReactOS in a temporary environment that will be reset in a restart. <span class="text-danger font-weight-bold">Please note, that ReactOS is still in alpha and gives no guarantee of stability, safety of your files or working at all.</span></p>
+<h2>What does the Boot Media offer?</h2>
+<p>The ReactOS Boot Media offers you the possibility of either installing ReactOS on your machine, or alternatively, trying ReactOS without the need for installation.
+Once you start the Boot Media, it presents a menu allowing you to select what you want to do: either running the Setup environment, or the Live environment for testing.
+Select the Setup environment if you wish to install ReactOS on your machine. You will be directed to the setup program, please follow the instructions given on the screen.
+On the other hand, the Live environment is useful if you don't plan to install or keep ReactOS on your computer for a longer period of time. It allows you to explore ReactOS in a temporary environment that will be reset at restart. <span class="text-danger font-weight-bold">Please note, that ReactOS is still in alpha and gives no guarantee of stability, safety of your files or working at all.</span></p>
 
 <h2>What do I do with this?</h2>
 <p><a href="/wiki">ReactOS Wiki</a> is an ideal source of information, it will help you setup ReactOS in your desired environment. <a href="https://reactos.org/wiki/Installing_ReactOS">"Installing ReactOS"</a> page should help you get started.</p>
@@ -42,7 +44,7 @@ date: 2021-01-23
 		<div class="modal-body">
 			{{< paypal >}}
 		</div>
-		<div class="modal-footer"><a id="download" href="" style="font-size: 16px;">No, thanks. Let's proceed with the download! </a></div>
+		<div class="modal-footer"><a id="download" href="" style="font-size: 16px;">No, thanks. Let's proceed with the download!</a></div>
 	</div>
 </div>
 </div>

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -1,12 +1,7 @@
 var bootcd = $("#bootcd").attr("href");
-var livecd = $("#livecd").attr("href");
 $("#bootcd").removeAttr("href");
-$("#livecd").removeAttr("href");
 $(".modalbtn").click(function(e){
   $("#bootcdModal").modal("toggle");
   url = bootcd;
-  if (e.target.textContent == "LiveCD") {
-    url = livecd;
-  }
   $('.modal-footer a').attr("href", url)
 });


### PR DESCRIPTION
ReactOS commit https://github.com/reactos/reactos/commit/b2e33f26eb3230c1a1535b6ea2833b0bb1ad128b removed the separate livecd artifact, merging it with the bootcd. Rename also "bootcd" to "Installation Medium", since it's more generic (e.g. the ISO can be flashed onto an USB thumb drive).

The text of the download.html is reworded to explain what the "Installation Medium" does.

_**I've also fixed the Download button, following commit f628d738c8 (PR #142).**_

### _The page: https://pr138.web-content.reactos.org/download/_