### PR TITLE
Fix the Download button following PR #142

### DIFF
--- a/static/js/download.js
+++ b/static/js/download.js
@@ -2,7 +2,7 @@ var bootcd = $("#bootcd").attr("href");
 var livecd = $("#livecd").attr("href");
 $("#bootcd").removeAttr("href");
 $("#livecd").removeAttr("href");
-$(".modalbtn").click(function(e){
+$(".buttons").click(function(e){
   $("#bootcdModal").modal("toggle");
   url = bootcd;
   if (e.target.textContent == "LiveCD") {


### PR DESCRIPTION
PR #142 changed the "Download BootCD" button JS class, and therefore caused the button to not work anymore.
This was picked up by @Copilot as part of the review of PR #138.