### PR TITLE
Update reactos-0415-released.md - Networking

### DIFF
--- a/content/project-news/reactos-0415-released.md
+++ b/content/project-news/reactos-0415-released.md
@@ -36,6 +36,9 @@ Oleg added support for more audio formats, looped playback of wave files, higher
 In addition, Victor Perevertkin imported the open source AC'97 driver from the Windows Driver Kit (WDK).
 This enables sound out of the box in VirtualBox when the virtual machine is configured to use the ICH AC'97 Audio Controller and various motherboards from 2004 and earlier.
 
+## Networking
+Dmitry Borisov's contribution has improved support for additional legacy networking hardware with the introduction of a new DC21X4 network adapter driver. This expands ReactOS compatibility with older DECchip 21x4-based adapters and improves networking support in legacy virtualization environments using emulated DEC 21140 hardware available in Microsoft Virtual PC 2007 and Hyper-V Generation 1.
+
 ## Memory Manager and Cache Controller
 Section Objects have been refactored by Jérôme Gardou (zefklop) for better compatibility with Windows.
 This fixes a long-standing bug preventing executables from starting in remote locations, such as network shares or virtual machine shared folders.

--- a/content/project-news/reactos-0415-released.md
+++ b/content/project-news/reactos-0415-released.md
@@ -37,7 +37,7 @@ In addition, Victor Perevertkin imported the open source AC'97 driver from the W
 This enables sound out of the box in VirtualBox when the virtual machine is configured to use the ICH AC'97 Audio Controller and various motherboards from 2004 and earlier.
 
 ## Networking
-Dmitry Borisov's contribution has improved support for additional legacy networking hardware with the introduction of a new DC21X4 network adapter driver. This expands ReactOS compatibility with older DECchip 21x4-based adapters and improves networking support in legacy virtualization environments using emulated DEC 21140 hardware available in Microsoft Virtual PC 2007 and Hyper-V Generation 1.
+Dmitry Borisov added support for more legacy networking hardware with a new DC21X4 network adapter driver. This expands ReactOS compatibility with older DECchip 21x4-based adapters and improves networking support in legacy virtualization environments using emulated DEC 21140 hardware, such as Microsoft Virtual PC 2007 and Hyper-V Generation 1.
 
 ## Memory Manager and Cache Controller
 Section Objects have been refactored by Jérôme Gardou (zefklop) for better compatibility with Windows.


### PR DESCRIPTION
I would like to add a short note about PR #5614 to the ReactOS 0.4.15 release notes. This driver was introduced during the 0.4.15 development cycle and adds support for DC21X4 network adapters, including DEC 21140 emulation used by Microsoft Virtual PC 2007 and Hyper-V Generation 1.

I apologize for bringing this up after the release. I wanted to include this information earlier, but I was not familiar with the process of updating the release notes.